### PR TITLE
Update renovate.json to remove package rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,20 +11,5 @@
     ]
   },
   "osvVulnerabilityAlerts": true,
-  "dependencyDashboardOSVVulnerabilitySummary": "all",
-  "packageRules": [
-    {
-      "matchManagers": [
-        "pep621"
-      ],
-      "matchPackageNames": [
-        "*"
-      ],
-      "rangeStrategy": "bump",
-      "labels": [
-        "PyProject",
-        "dependencies"
-      ]
-    }
-  ]
+  "dependencyDashboardOSVVulnerabilitySummary": "all"
 }


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Drop the packageRules section from .github/renovate.json