### PR TITLE
Remove OSV vulnerability alerts from renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,5 @@
       "Lockfile",
       "dependencies"
     ]
-  },
-  "osvVulnerabilityAlerts": true,
-  "dependencyDashboardOSVVulnerabilitySummary": "all"
+  }
 }


### PR DESCRIPTION
Removed OSV vulnerability alerts and dashboard summary settings.

## Summary by Sourcery

Remove OSV vulnerability alerts and dashboard summary settings from the Renovate configuration

Chores:
- Remove OSV vulnerability alert configuration
- Remove dashboard summary settings