### PR TITLE
Disable PEP 621 in renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
       "dependencies"
     ]
   },
-  "osvVulnerabilityAlerts": true,
-  "dependencyDashboardOSVVulnerabilitySummary": "all"
+  "pep621": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove PEP 621 parsing from .github/renovate.json to prevent Renovate from updating dependencies via pyproject.toml