### PR TITLE
Update Mergify configuration to remove branch deletion

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -14,11 +14,6 @@ pull_request_rules:
       - files = .trunk/trunk.yaml
     actions:
       merge:
-  - name: Delete branch after close
-    conditions:
-      - closed
-    actions:
-      delete_head_branch:
   - name: Comment when a pull request is merged
     conditions:
       - merged
@@ -83,6 +78,6 @@ queue_rules:
           - check-success = GitGuardian Security Checks
           - check-success = SonarCloud
           - check-success = Trunk Check
-          - check-success = CodeRabbit
           - check-success = Test Image / API Test
           - check-success = CodeQL
+          # - check-success = CodeRabbit


### PR DESCRIPTION
Removed the action to delete branches after closing pull requests and commented out the CodeRabbit check.

## Summary by Sourcery

Update Mergify configuration to disable automatic branch deletion and temporarily disable the CodeRabbit check

CI:
- Remove the head branch deletion action after pull request closure in Mergify
- Comment out the CodeRabbit check in Mergify queue rules